### PR TITLE
Added Url Activation Query string parameters

### DIFF
--- a/Applications/Views/Setup/Index.cshtml
+++ b/Applications/Views/Setup/Index.cshtml
@@ -1,5 +1,4 @@
 ﻿@using UACloudTwin.Models
-
 @model SetupModel
 
 @{
@@ -16,11 +15,11 @@
         </p>
         <p>
             Please provide a connection string for the broker. Alternatively, you can define environment variables (see readme).<br />
-            @Html.TextBox("endpoint", null, new { style = "width:100%;" })<br />
+            @Html.TextBox("endpoint", (Context.Request.Query.ContainsKey("endpoint") ? Context.Request.Query["endpoint"] : (string)null), new { style = "width:100%;" })<br />
         <p />
         <p>
             Please provide an instance Url to your Digital Twin service<br />
-            @Html.TextBox("instanceUrl", null, new { style = "width:100%;" })<br />
+            @Html.TextBox("instanceUrl", (Context.Request.Query.ContainsKey("instanceUrl") ? Context.Request.Query["instanceUrl"] : (string)null), new { style = "width:100%;" })<br />
         <p />
         <p>
             <input id="uploadButton" class="btn btn-primary btn_browser" type="submit" value="Apply">

--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ Alternatively,  you can run it in a Docker-enabled web application in the Cloud.
 
 Then point your web browser to <http://yourIPAddress>
 
+You can navigate optionally supply the following query parameters:
+
+* `?endpoint=your-broker-connection-string` - the connection strng of the broker to use
+* `?instanceurl=your-adt-instance-url` - the URL of the Azure Digital Twins instance to use
+
+e.g. <https://localhost:5001/Setup?endpoint=[your-connection-string]&instanceUrl=[your-adt-instance-url]>
+ 
+
 ## Build Status
 
 [![Docker](https://github.com/digitaltwinconsortium/UA-CloudTwin/actions/workflows/docker-build.yml/badge.svg)](https://github.com/digitaltwinconsortium/UA-CloudTwin/actions/workflows/docker-build.yml)
+

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Alternatively,  you can run it in a Docker-enabled web application in the Cloud.
 
 Then point your web browser to <http://yourIPAddress>
 
-You can navigate optionally supply the following query parameters:
+You can optionally supply the following query parameters:
 
 * `?endpoint=your-broker-connection-string` - the connection strng of the broker to use
 * `?instanceurl=your-adt-instance-url` - the URL of the Azure Digital Twins instance to use


### PR DESCRIPTION
Added the Ability to prefill the endpoint and adt instance fields from the query string.

i.e.

`https://your-ip/Setup?endpoint=[your-connection-string]&instanceUrl=[your-adt-instance-url]`

so my instance is

` https://your-ip/Setup?endpoint=Endpoint=sb://[service-bus-name].servicebus.windows.net/;SharedAccessKeyName=iothubowner;SharedAccessKey=[my-key];EntityPath=[iot-hub-name]&instanceUrl=https://ah-adt-isa95-01.api.weu.digitaltwins.azure.net`

This might be useful when scripting out the deployment